### PR TITLE
add aarch64 linux release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
           include:
             - target: x86_64-unknown-linux-musl
               os: ubuntu-latest
+            - target: aarch64-unknown-linux-musl
+              os: ubuntu-latest
             - target: x86_64-apple-darwin
               os: macos-latest
             - target: aarch64-apple-darwin


### PR DESCRIPTION
Added aarch64 linux release to release actions. I’ve tested the action and the built package — both work correctly.